### PR TITLE
Add Blazor Modal Component 

### DIFF
--- a/ChessClient/BlazorWASM/Pages/Modals/ModalComponent.razor
+++ b/ChessClient/BlazorWASM/Pages/Modals/ModalComponent.razor
@@ -1,0 +1,5 @@
+﻿<h3>ModalComponent</h3>
+
+@code {
+    
+}

--- a/ChessClient/BlazorWASM/_Imports.razor
+++ b/ChessClient/BlazorWASM/_Imports.razor
@@ -8,3 +8,5 @@
 @using Microsoft.JSInterop
 @using BlazorWASM
 @using BlazorWASM.Shared
+//imported BootstrapBlazor(2)
+@using BlazorBootstrap


### PR DESCRIPTION
Add a Modal Component Template that can be used later for pop ups and Import Blazor Bootstrap from NuGet to BlazorWASM.